### PR TITLE
docs: Add documentation for set_image_pull_secrets

### DIFF
--- a/kubernetes_platform/python/README.md
+++ b/kubernetes_platform/python/README.md
@@ -289,3 +289,21 @@ def pipeline():
     task = simple_task()
     kubernetes.set_image_pull_policy(task, "Always")
 ```
+
+### ImagePullSecrets: Set secrets to pull private images
+```python
+from kfp import dsl
+from kfp import kubernetes
+
+@dsl.container_component
+def hello():
+    return dsl.ContainerSpec(
+        image='some-private-image:tag',
+        command=['echo', 'hello']
+    )
+
+@dsl.pipeline
+def pipeline():
+    task = hello()
+    kubernetes.set_image_pull_secrets(task, ['secret-name'])
+```


### PR DESCRIPTION
**Description of your changes:**

This PR adds documentation for set_image_pull_secrets added in https://github.com/kubeflow/pipelines/pull/10427

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
